### PR TITLE
Tidy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # StrEnum.System.Text.Json
 
-Allows for [StrEnum](https://github.com/StrEnum/StrEnum/) string enum JSON serialization and deserialization with System.Text.Json.
+Lets you serialize and deserialize [StrEnum](https://github.com/StrEnum/StrEnum/) string enums to JSON via System.Text.Json.
 
-The package targets .NET Standard 2.0 and can be used with System.Text.Json 4.6.0-10.\*.
+Targets .NET Standard 2.0; works with System.Text.Json 4.6.0 – 10.x.
 
 ## Installation
 
-You can install [StrEnum.System.Text.Json](https://www.nuget.org/packages/StrEnum.System.Text.Json/) using the .NET CLI:
+Install [StrEnum.System.Text.Json](https://www.nuget.org/packages/StrEnum.System.Text.Json/) via the .NET CLI:
 
 ```
 dotnet add package StrEnum.System.Text.Json
@@ -14,7 +14,7 @@ dotnet add package StrEnum.System.Text.Json
 
 ## Usage
 
-Create a string enum and a class that contains it:
+### Defining a string enum and a model
 
 ```csharp
 public class Sport : StringEnum<Sport>
@@ -29,33 +29,31 @@ public class Race
 }
 ```
 
-Configure `JsonSerializerOptions` by calling the `UseStringEnums()` method and pass it to `JsonSerializer` :
+### Configuring the serializer
+
+Call `UseStringEnums()` on a `JsonSerializerOptions` instance and pass it to `JsonSerializer`:
 
 ```csharp
 var options = new JsonSerializerOptions().UseStringEnums();
 ```
 
-### Serialize to JSON:
+### Serializing to JSON
 
 ```csharp
-var ctct = new Race { Name = "Cape Town Cycle Tour", Sport = Sport.RoadCycling };
+var race = new Race { Name = "Cape Town Cycle Tour", Sport = Sport.RoadCycling };
 
-var json = JsonSerializer.Serialize(ctct, options);
+var json = JsonSerializer.Serialize(race, options);
 ```
 
-The above produces:
+Produces:
 
 ```json
 {"Name":"Cape Town Cycle Tour","Sport":"ROAD_CYCLING"}
 ```
 
-### Deserialize from JSON:
+### Deserializing from JSON
 
-```json
-{"Name":"Cape Town Cycle Tour","Sport":"ROAD_CYCLING"}
-```
-
-The above JSON can be deserialized into a C# object that contains a StrEnum enum:
+The same JSON can be deserialized back to a `Race`:
 
 ```csharp
 var race = JsonSerializer.Deserialize<Race>(json, options);


### PR DESCRIPTION
## Summary
- Same readability pass applied across the StrEnum family ([StrEnum](https://github.com/StrEnum/StrEnum/pull/12), [StrEnum.EntityFrameworkCore](https://github.com/StrEnum/StrEnum.EntityFrameworkCore/pull/7), [StrEnum.AspNetCore](https://github.com/StrEnum/StrEnum.AspNetCore/pull/6)). README copy only, no code changes.
- Adds sub-headings inside **Usage** so the section isn't a wall of prose:
  - `### Defining a string enum and a model`
  - `### Configuring the serializer`
  - `### Serializing to JSON`
  - `### Deserializing from JSON`
- Style tweaks: `Allows for ... JSON serialization and deserialization` → `Lets you serialize and deserialize ... to JSON`; `The package targets .NET Standard 2.0 and can be used with System.Text.Json 4.6.0-10.*` → tighter and en-dashed; `You can install ... using` → `Install ... via`; drops trailing-colon heading style (`### Serialize to JSON:` → `### Serializing to JSON`).
- Code samples: rename the cryptic `ctct` variable to `race`; remove the duplicated JSON snippet in the Deserialize section (refers back to the JSON shown in the Serialize section instead).

## Test plan
- [x] Render the README to verify formatting and the new sub-headings
- [x] Confirm code samples still match the package's actual API